### PR TITLE
Prevent render blocking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import "./styles/Variables.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 
+import { bootstrap } from "./store/actions";
 import { store } from "./store/store";
 import { Provider } from "react-redux";
 
@@ -12,7 +13,8 @@ ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById("root")
+  document.getElementById("root"),
+  () => store.dispatch(bootstrap())
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,7 +1,6 @@
 import { createStore, applyMiddleware, compose } from "redux";
 import { startupMiddleware, stockMiddleware } from "./middleware";
 import { combinedReducer } from "./reducer";
-import { bootstrap } from "./actions";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
@@ -10,5 +9,3 @@ export const store = createStore(
   undefined,
   composeEnhancers(applyMiddleware(...[stockMiddleware, startupMiddleware]))
 );
-
-store.dispatch(bootstrap());


### PR DESCRIPTION
Prevent render blocking by moving initial action 'bootstrap' to dispatch during a ReactDOM.render callback