### PR TITLE
Added script to start up server environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5359,7 +5359,8 @@
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "dotenv-expand": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start-server": "nodemon ./server/server",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
To fix issue #57, server can now be started using `npm run start-server`